### PR TITLE
(bug) fix global operator in regex

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1743,7 +1743,7 @@
   lineinfile:
     dest: /etc/sysconfig/sshd
     state: absent
-    regexp: ^\s*(?i)CRYPTO_POLICY.*$
+    regexp: (?i)^\s*CRYPTO_POLICY.*$
   tags:
   - CCE-83445-7
   - NIST-800-53-AC-17(2)


### PR DESCRIPTION
Similar to https://github.com/RedHatOfficial/ansible-role-rhel8-stig/pull/9.

My setup:
RHEL 9.2
ansible-core 2.14
python 3.11