### PR TITLE
fix for meta/main.yml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
   role_name: rhel9_stig
   author: ComplianceAsCode development team
-  description: [DRAFT] DISA STIG for Red Hat Enterprise Linux 9
+  description: "[DRAFT] DISA STIG for Red Hat Enterprise Linux 9"
 
   issue_tracker_url: https://github.com/ComplianceAsCode/content/issues
 


### PR DESCRIPTION
Error:
```
ansible-galaxy role install git+https://github.com/RedHatOfficial/ansible-role-rhel9-stig
Starting galaxy role install process
[WARNING]: - ansible-role-rhel9-stig was NOT installed successfully: this role does not appear to have a valid
meta/main.yml file.
ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
```

make meta/main.yml valid so this repo can be installed via:
`ansible-galaxy role install git+https://github.com/RedHatOfficial/ansible-role-rhel9-stig`

Also, please update the role on Ansible Galaxy: https://galaxy.ansible.com/ui/standalone/roles/RedHatOfficial/rhel9_stig/