### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ N/A
 Example Role Usage
 ----------------
 
-Run `ansible-galaxy install RedHatOfficial.rhel9_stig` to
+Run `ansible-galaxy install RedHatOfficial.rhel9-stig` to
 download and install the role. Then, you can use the following playbook snippet to run the Ansible role:
 
     - hosts: all
       roles:
-         - { role: RedHatOfficial.rhel9_stig }
+         - { role: RedHatOfficial.rhel9-stig }
 
 Next, check the playbook using (on the localhost) the following example:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# defaults file for rhel9_stig
+# defaults file for rhel9-stig
 var_aide_scan_notification_email: root@localhost
 var_system_crypto_policy: FIPS
 inactivity_timeout_value: '900'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,5 @@
 galaxy_info:
-  role_name: rhel9_stig
+  role_name: rhel9-stig
   author: ComplianceAsCode development team
   description: DISA STIG for Red Hat Enterprise Linux 9
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-# defaults file for rhel9_stig
+# defaults file for rhel9-stig


### PR DESCRIPTION
There seem to be two roles set up, `RedHatOfficial.rhel9_stig` and `RedHatOfficial.rhel9-stig`.
`RedHatOfficial.rhel9-stig` is the one that is more up-to-date, so I have changed any references to reflect that.